### PR TITLE
Improve GraphUtil standard deviation computation performance

### DIFF
--- a/src/main/java/jenkins/plugins/model/StandardDeviationMetric.java
+++ b/src/main/java/jenkins/plugins/model/StandardDeviationMetric.java
@@ -21,6 +21,12 @@ public class StandardDeviationMetric implements AggregateBuildMetric {
         metric = (long) statistics.getStandardDeviation();
     }
 
+    private StandardDeviationMetric(String name, long metric, int occurences) {
+        this.name = name;
+        this.metric = metric;
+        this.occurences = occurences;
+    }
+
     @Override
     public int getOccurences() {
         return occurences;
@@ -34,5 +40,28 @@ public class StandardDeviationMetric implements AggregateBuildMetric {
     @Override
     public String getName() {
         return name;
+    }
+
+    public static Builder newBuilderFor(String name) {
+       return new Builder(name); 
+    }
+    
+    public static class Builder {
+        private final SummaryStatistics statistics = new SummaryStatistics();
+        private final String name;
+
+        private Builder(String name) {
+            this.name = name;
+        }
+
+        public void addMessage(BuildMessage message) {
+            statistics.addValue(message.getDuration());
+        }
+
+        public StandardDeviationMetric build() {
+            return new StandardDeviationMetric(name, 
+                    (long) statistics.getStandardDeviation(),
+                    Math.toIntExact(statistics.getN()));
+        }
     }
 }

--- a/src/main/java/jenkins/plugins/util/GraphUtil.java
+++ b/src/main/java/jenkins/plugins/util/GraphUtil.java
@@ -29,13 +29,10 @@ public class GraphUtil {
         XYSeriesCollection dataset = new XYSeriesCollection();
         XYSeries series1 = new XYSeries("Object 1");
 
-        //Need to optimise this, it's O(n^2)
+        StandardDeviationMetric.Builder metricBuilder = StandardDeviationMetric.newBuilderFor("Graph");
         for(int i=0; i<buildMessages.size(); i++){
-
-            List<BuildMessage> sublist = buildMessages.subList(i, buildMessages.size() - 1);
-            System.out.println(sublist.get(0));
-            StandardDeviationMetric metric = new StandardDeviationMetric("Graph", sublist);
-            series1.add(metric.calculateMetric(), i);
+            metricBuilder.addMessage(buildMessages.get(i));
+            series1.add(metricBuilder.build().calculateMetric(), i);
         }
 
         dataset.addSeries(series1);

--- a/src/test/java/jenkins/plugins/model/StandardDeviationMetricTest.java
+++ b/src/test/java/jenkins/plugins/model/StandardDeviationMetricTest.java
@@ -57,8 +57,41 @@ public class StandardDeviationMetricTest {
         runAndVerifyResult(Lists.newArrayList(FIRST_BUILD, SECOND_BUILD), 707L, 2);
     }
 
+    @Test
+    public void should_return_correct_stddev_with_multiple_builds() {
+        StandardDeviationMetric.Builder builder = StandardDeviationMetric.newBuilderFor("test");
+        builder.addMessage(FIRST_BUILD);
+        verifyResult(builder.build(), 0, 1);
+
+        builder.addMessage(SECOND_BUILD);
+        verifyResult(builder.build(), 707, 2);
+
+        builder.addMessage(THIRD_BUILD);
+        verifyResult(builder.build(), 1000, 3);
+
+        builder.addMessage(FOURTH_BUILD);
+        verifyResult(builder.build(), 1290, 4);
+
+        builder.addMessage(FIFTH_BUILD);
+        verifyResult(builder.build(), 1581, 5);
+
+        builder.addMessage(SIXTH_BUILD);
+        verifyResult(builder.build(), 1870, 6);
+
+        builder.addMessage(SEVENTH_BUILD);
+        verifyResult(builder.build(), 2160, 7);
+
+        builder.addMessage(EIGHTH_BUILD);
+        verifyResult(builder.build(), 2449, 8);
+
+    }
+
     private void runAndVerifyResult(List<BuildMessage> builds, long expectTime, int expectCount) {
         AggregateBuildMetric stddevMetric = new StandardDeviationMetric("test", builds);
+        verifyResult(stddevMetric, expectTime, expectCount);
+    }
+
+    private void verifyResult(AggregateBuildMetric stddevMetric, long expectTime, int expectCount) {
         assertEquals("Metric Name", "test", stddevMetric.getName());
         assertEquals("StandardDeviationMetric", expectTime, stddevMetric.calculateMetric());
         assertEquals("Build Count", expectCount, stddevMetric.getOccurences());

--- a/src/test/java/jenkins/plugins/util/GraphUtilTest.java
+++ b/src/test/java/jenkins/plugins/util/GraphUtilTest.java
@@ -1,0 +1,41 @@
+package jenkins.plugins.util;
+
+import hudson.model.Result;
+import jenkins.plugins.model.BuildMessage;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.xy.XYDataset;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class GraphUtilTest {
+    private static final long TODAY = new Date().getTime();
+    private static final BuildMessage FIRST_BUILD = new BuildMessage(1, TODAY, 1500, Result.SUCCESS.toString());
+    private static final BuildMessage SECOND_BUILD = new BuildMessage(2, TODAY + 1000, 2500, Result.FAILURE.toString());
+    private static final BuildMessage THIRD_BUILD = new BuildMessage(3, TODAY + 2000, 3500, Result.FAILURE.toString());
+    private static final BuildMessage FOURTH_BUILD = new BuildMessage(4, TODAY + 3000, 4500, Result.SUCCESS.toString());
+    private static final BuildMessage FIFTH_BUILD = new BuildMessage(5, TODAY + 4000, 5500, Result.FAILURE.toString());
+    private static final BuildMessage SIXTH_BUILD = new BuildMessage(6, TODAY + 5000, 6500, Result.SUCCESS.toString());
+    private static final BuildMessage SEVENTH_BUILD = new BuildMessage(7, TODAY + 7000, 7500, Result.ABORTED.toString());
+    private static final BuildMessage EIGHTH_BUILD = new BuildMessage(8, TODAY + 8000, 8500, Result.UNSTABLE.toString());
+
+    @Test
+    public void should_return_graph_data() {
+        JFreeChart chart = GraphUtil.generateStdDevGraph("test", 
+                Arrays.asList(FIRST_BUILD, SECOND_BUILD, THIRD_BUILD, FOURTH_BUILD, FIFTH_BUILD, SIXTH_BUILD, SEVENTH_BUILD, EIGHTH_BUILD));
+        XYDataset dataset = chart.getXYPlot().getDataset();
+        assertEquals(8, dataset.getItemCount(0));
+        assertEquals(0d, dataset.getX(0, 0));
+        assertEquals(707d, dataset.getX(0, 1));
+        assertEquals(1000d, dataset.getX(0, 2));
+        assertEquals(1290d, dataset.getX(0, 3));
+        assertEquals(1581d, dataset.getX(0, 4));
+        assertEquals(1870d, dataset.getX(0, 5));
+        assertEquals(2160d, dataset.getX(0, 6));
+        assertEquals(2449d, dataset.getX(0, 7));
+    }
+
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Address Standard deviation computation performance in GraphUtil by
keeping the previous statistics while going over the builds.

Also fix jenkinsci/build-history-metrics-plugin#10